### PR TITLE
Fix relative address overflow issues

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -300,8 +300,14 @@ impl Instruction {
             Zeropage => format!("${:02X}", operand),
             ZeropageIndexedX => format!("${:02X},X", operand),
             ZeropageIndexedY => format!("${:02X},Y", operand),
-            // TODO: check wrapping?
-            Relative => format!("${:04X}", (self.address as i16 + (2 + operand as i8) as i16) as u16),
+            Relative => format!(
+                "${:04X}",
+                self.address
+                    // Add 2 for the next PC value
+                    .wrapping_add(2)
+                    // Add the sign-extended offset
+                    .wrapping_add(operand as i8 as u16)
+            ),
             Indirect => format!("(${:04X})", operand),
             IndexedIndirectX    => format!("(${:02X},X)", operand),
             IndirectIndexedY(_) => format!("(${:02X}),Y", operand)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ pub fn from_addr_array(bytes: &[u8], start_address: u16) -> Result<Vec<Instructi
     while index < bytes.len() {
         let instruction = instruction::decode(next_addr, &mut index, &bytes);
         ret.push(instruction);
-        next_addr = start_address + index as u16;
+        next_addr = start_address.wrapping_add(index as u16);
     }
 
     Ok(ret)

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -63,3 +63,95 @@ fn check_disasm_file() {
 #[should_panic]
 fn check_disasm_file_fail() {
     let _ = disasm6502::from_file("tests/foo").unwrap_or_else(|e| { panic!("{}", e); }); }
+
+#[test]
+fn check_relative_addressing() {
+    const BEQ: u8 = 0xF0;
+
+    // Test various relative addressing edge conditions
+    struct RelativeTest {
+        start: u16,
+        bytes: &'static [u8],
+        expect: u16
+    };
+    static TESTS: [RelativeTest; 60] = [
+        RelativeTest { start: 0x0000, bytes: &[BEQ, 0xFD], expect: 0xFFFF },
+        RelativeTest { start: 0x0000, bytes: &[BEQ, 0xFE], expect: 0x0000 },
+        RelativeTest { start: 0x0000, bytes: &[BEQ, 0xFF], expect: 0x0001 },
+        RelativeTest { start: 0x0000, bytes: &[BEQ, 0x00], expect: 0x0002 },
+        RelativeTest { start: 0x0000, bytes: &[BEQ, 0x01], expect: 0x0003 },
+        RelativeTest { start: 0x0000, bytes: &[BEQ, 0x02], expect: 0x0004 },
+        RelativeTest { start: 0x0000, bytes: &[BEQ, 0x7D], expect: 0x007F },
+        RelativeTest { start: 0x0000, bytes: &[BEQ, 0x7E], expect: 0x0080 },
+        RelativeTest { start: 0x0000, bytes: &[BEQ, 0x7F], expect: 0x0081 },
+        RelativeTest { start: 0x0000, bytes: &[BEQ, 0x80], expect: 0xFF82 },
+        RelativeTest { start: 0x0000, bytes: &[BEQ, 0x81], expect: 0xFF83 },
+        RelativeTest { start: 0x0000, bytes: &[BEQ, 0x82], expect: 0xFF84 },
+        RelativeTest { start: 0x4000, bytes: &[BEQ, 0xFD], expect: 0x3FFF },
+        RelativeTest { start: 0x4000, bytes: &[BEQ, 0xFE], expect: 0x4000 },
+        RelativeTest { start: 0x4000, bytes: &[BEQ, 0xFF], expect: 0x4001 },
+        RelativeTest { start: 0x4000, bytes: &[BEQ, 0x00], expect: 0x4002 },
+        RelativeTest { start: 0x4000, bytes: &[BEQ, 0x01], expect: 0x4003 },
+        RelativeTest { start: 0x4000, bytes: &[BEQ, 0x02], expect: 0x4004 },
+        RelativeTest { start: 0x4000, bytes: &[BEQ, 0x7D], expect: 0x407F },
+        RelativeTest { start: 0x4000, bytes: &[BEQ, 0x7E], expect: 0x4080 },
+        RelativeTest { start: 0x4000, bytes: &[BEQ, 0x7F], expect: 0x4081 },
+        RelativeTest { start: 0x4000, bytes: &[BEQ, 0x80], expect: 0x3F82 },
+        RelativeTest { start: 0x4000, bytes: &[BEQ, 0x81], expect: 0x3F83 },
+        RelativeTest { start: 0x4000, bytes: &[BEQ, 0x82], expect: 0x3F84 },
+        RelativeTest { start: 0x7FFF, bytes: &[BEQ, 0xFD], expect: 0x7FFE },
+        RelativeTest { start: 0x7FFF, bytes: &[BEQ, 0xFE], expect: 0x7FFF },
+        RelativeTest { start: 0x7FFF, bytes: &[BEQ, 0xFF], expect: 0x8000 },
+        RelativeTest { start: 0x7FFF, bytes: &[BEQ, 0x00], expect: 0x8001 },
+        RelativeTest { start: 0x7FFF, bytes: &[BEQ, 0x01], expect: 0x8002 },
+        RelativeTest { start: 0x7FFF, bytes: &[BEQ, 0x02], expect: 0x8003 },
+        RelativeTest { start: 0x7FFF, bytes: &[BEQ, 0x7D], expect: 0x807E },
+        RelativeTest { start: 0x7FFF, bytes: &[BEQ, 0x7E], expect: 0x807F },
+        RelativeTest { start: 0x7FFF, bytes: &[BEQ, 0x7F], expect: 0x8080 },
+        RelativeTest { start: 0x7FFF, bytes: &[BEQ, 0x80], expect: 0x7F81 },
+        RelativeTest { start: 0x7FFF, bytes: &[BEQ, 0x81], expect: 0x7F82 },
+        RelativeTest { start: 0x7FFF, bytes: &[BEQ, 0x82], expect: 0x7f83 },
+        RelativeTest { start: 0x8000, bytes: &[BEQ, 0xFD], expect: 0x7FFF },
+        RelativeTest { start: 0x8000, bytes: &[BEQ, 0xFE], expect: 0x8000 },
+        RelativeTest { start: 0x8000, bytes: &[BEQ, 0xFF], expect: 0x8001 },
+        RelativeTest { start: 0x8000, bytes: &[BEQ, 0x00], expect: 0x8002 },
+        RelativeTest { start: 0x8000, bytes: &[BEQ, 0x01], expect: 0x8003 },
+        RelativeTest { start: 0x8000, bytes: &[BEQ, 0x02], expect: 0x8004 },
+        RelativeTest { start: 0x8000, bytes: &[BEQ, 0x7D], expect: 0x807F },
+        RelativeTest { start: 0x8000, bytes: &[BEQ, 0x7E], expect: 0x8080 },
+        RelativeTest { start: 0x8000, bytes: &[BEQ, 0x7F], expect: 0x8081 },
+        RelativeTest { start: 0x8000, bytes: &[BEQ, 0x80], expect: 0x7F82 },
+        RelativeTest { start: 0x8000, bytes: &[BEQ, 0x81], expect: 0x7F83 },
+        RelativeTest { start: 0x8000, bytes: &[BEQ, 0x82], expect: 0x7F84 },
+        RelativeTest { start: 0xFFFF, bytes: &[BEQ, 0xFD], expect: 0xFFFE },
+        RelativeTest { start: 0xFFFF, bytes: &[BEQ, 0xFE], expect: 0xFFFF },
+        RelativeTest { start: 0xFFFF, bytes: &[BEQ, 0xFF], expect: 0x0000 },
+        RelativeTest { start: 0xFFFF, bytes: &[BEQ, 0x00], expect: 0x0001 },
+        RelativeTest { start: 0xFFFF, bytes: &[BEQ, 0x01], expect: 0x0002 },
+        RelativeTest { start: 0xFFFF, bytes: &[BEQ, 0x02], expect: 0x0003 },
+        RelativeTest { start: 0xFFFF, bytes: &[BEQ, 0x7D], expect: 0x007E },
+        RelativeTest { start: 0xFFFF, bytes: &[BEQ, 0x7E], expect: 0x007F },
+        RelativeTest { start: 0xFFFF, bytes: &[BEQ, 0x7F], expect: 0x0080 },
+        RelativeTest { start: 0xFFFF, bytes: &[BEQ, 0x80], expect: 0xFF81 },
+        RelativeTest { start: 0xFFFF, bytes: &[BEQ, 0x81], expect: 0xFF82 },
+        RelativeTest { start: 0xFFFF, bytes: &[BEQ, 0x82], expect: 0xFF83 },
+    ];
+
+    for test in TESTS.iter() {
+        // Disassemble the instruction
+        let instructions = disasm6502::from_addr_array(&test.bytes, test.start).unwrap();
+        assert_eq!(instructions.len(), 1);
+        let disassembly = format!("{}", instructions.get(0).unwrap());
+        // Extract the address of the branch target
+        let address = u16::from_str_radix(
+            disassembly
+                .split_ascii_whitespace()
+                .last()
+                .unwrap()
+                .trim_start_matches('$'),
+            16,
+        ).unwrap();
+        // Confirm the relative address was applied correctly.
+        assert_eq!(address, test.expect);
+    }
+}


### PR DESCRIPTION
Certain branch instructions could not be disassembled due to "attempt to add with overflow" panics. For example, the following instruction will always cause a panic when disassembled:

```
7f93  B0 6F       BCS $8004
```

This patch fixes the relative address resolution arithmetic and provides a number of edge condition tests.