### PR TITLE
Fix warnings

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -329,7 +329,7 @@ fn read_byte(index: usize, buffer: &[u8]) -> u16 {
 
 // read word: Little Endian (0x0000 if can't fetch)
 fn read_word_le(index: &mut usize, buffer: &[u8]) -> u16 {
-    let value_be = (read_byte(*index, buffer) << 8 & 0xFF00) | (read_byte((*index + 0x0001), buffer) & 0x00FF);
+    let value_be = (read_byte(*index, buffer) << 8 & 0xFF00) | (read_byte(*index + 0x0001, buffer) & 0x00FF);
     *index += 1;
 
     ((value_be << 8) & 0xFF00) | ((value_be >> 8) & 0x00FF)
@@ -395,7 +395,7 @@ fn fetch(opcode: OpCode, num_cycles: u8, addr_mode: AddrMode, data: (u16, &mut u
     instruction.registers_written = reg_written;
     instruction.affected_flags = affected_flags;
 
-    if let Some(_) = ILLEGAL_OPS.into_iter().filter(|&&illegal| op_hex == illegal).next() {
+    if let Some(_) = ILLEGAL_OPS.iter().filter(|&&illegal| op_hex == illegal).next() {
         instruction.illegal = true;
     }
 
@@ -681,6 +681,5 @@ pub fn decode(address: u16, index: &mut usize, memory: &[u8]) -> Instruction {
         /* ISC_aby */ 0xFB => fetch(ISC(op), 7, AbsoluteIndexedY(false), data, sv![A,Y], sv![A]),
         /* NOP_abx */ 0xFC => fetch(NOP(op), 5, AbsoluteIndexedX(true), data, sv![X], None), // add 1 cycle if page boundary is crossed
         /* ISC_abx */ 0xFF => fetch(ISC(op), 7, AbsoluteIndexedX(false), data, sv![A,X], sv![A]),
-                         _ => fetch(NOP(op), 0, Implied, data, None, None)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,9 +60,9 @@ pub fn from_file(filename: &str) -> Result<Vec<Instruction>> {
 /// ```
 pub fn from_addr_file(filename: &str, start_address: u16) -> Result<Vec<Instruction>> {
     let path = Path::new(&filename);
-    let mut file = try!(File::open(&path));
+    let mut file = File::open(&path)?;
     let mut bytes = Vec::new();
-    try!(file.read_to_end(&mut bytes));
+    file.read_to_end(&mut bytes)?;
 
     from_addr_array(&bytes, start_address)
 }


### PR DESCRIPTION
This is a very minor cleanup PR to fix a few warnings generated by the latest stable Rust compiler (`rustc 1.46.0 (04488afe3 2020-08-24)`):

```
warning: use of deprecated item 'try': use the `?` operator instead
  --> /Users/simmons/work/disasm6502/src/lib.rs:63:20
   |
63 |     let mut file = try!(File::open(&path));
   |                    ^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: use of deprecated item 'try': use the `?` operator instead
  --> /Users/simmons/work/disasm6502/src/lib.rs:65:5
   |
65 |     try!(file.read_to_end(&mut bytes));
   |     ^^^

warning: unnecessary parentheses around function argument
   --> /Users/simmons/work/disasm6502/src/instruction.rs:332:75
    |
332 |     let value_be = (read_byte(*index, buffer) << 8 & 0xFF00) | (read_byte((*index + 0x0001), buffer) & 0x00FF);
    |                                                                           ^^^^^^^^^^^^^^^^^ help: remove these parentheses
    |
    = note: `#[warn(unused_parens)]` on by default

warning: unreachable pattern
   --> /Users/simmons/work/disasm6502/src/instruction.rs:684:26
    |
684 |                          _ => fetch(NOP(op), 0, Implied, data, None, None)
    |                          ^
    |
    = note: `#[warn(unreachable_patterns)]` on by default

warning: this method call currently resolves to `<&[T] as IntoIterator>::into_iter` (due to autoref coercions), but that might change in the future when `IntoIterator` impls for arrays are added.
   --> /Users/simmons/work/disasm6502/src/instruction.rs:398:34
    |
398 |     if let Some(_) = ILLEGAL_OPS.into_iter().filter(|&&illegal| op_hex == illegal).next() {
    |                                  ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = note: `#[warn(array_into_iter)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>
```